### PR TITLE
fixing small bug where wrong scale & smearing filename is displayed

### DIFF
--- a/RecoEgamma/EgammaTools/test/runEgammaPostRecoTools.py
+++ b/RecoEgamma/EgammaTools/test/runEgammaPostRecoTools.py
@@ -89,9 +89,9 @@ process.egammaOutput = cms.OutputModule("PoolOutputModule",
 process.outPath = cms.EndPath(process.egammaOutput)
 
 residualCorrFileName = None
-if hasattr(process,'calibratedPatElectrons'):
+if options.isMiniAOD:
     residualCorrFileName = process.calibratedPatElectrons.correctionFile.value()
-if hasattr(process,'calibratedElectrons'):
+else:
     residualCorrFileName = process.calibratedElectrons.correctionFile.value()
 msgStr='''EgammaPostRecoTools:
   running with GT: {}


### PR DESCRIPTION
Fixes a small bug which in the test script, the scale and smearings file is wrongly displayed for miniAOD (it always takes it from the AOD module as the AOD module always exists). Now it displays correctly. Has no impact on the file actually used so no issue outside the test script. 