### PR TITLE
Force reading miniAOD when in miniAOD mode

### DIFF
--- a/RecoEgamma/EgammaTools/python/EgammaPostRecoTools.py
+++ b/RecoEgamma/EgammaTools/python/EgammaPostRecoTools.py
@@ -267,6 +267,12 @@ def _setupEgammaPostRECOSequenceMiniAOD(process,applyEnergyCorrections=False,app
         process.photonIDValueMapProducer.srcMiniAOD = phoVIDSrc
         process.egmPhotonIsolation.srcToIsolate = phoVIDSrc
 
+        #we need to also zero out the AOD srcs as otherwise it gets confused in two tier jobs
+        #and bad things happen
+        process.electronMVAValueMapProducer.src = cms.InputTag("")
+        process.photonMVAValueMapProducer.src = cms.InputTag("")
+        process.photonIDValueMapProducer.src = cms.InputTag("")
+
     if runVID and hasattr(process,'heepIDVarValueMaps'):
         process.heepIDVarValueMaps.elesMiniAOD = eleVIDSrc
         process.heepIDVarValueMaps.dataFormat = 2


### PR DESCRIPTION
The electronMVA, photonMVA and photonID valuemap producers can all select their inputs based on data tier. This causes problems when reading an event with both AOD & miniAOD availible, specifically when you are doing a two file solution. 

This was reported by  https://hypernews.cern.ch/HyperNews/CMS/get/egamma/2239.html by Pedro Siliva and also https://hypernews.cern.ch/HyperNews/CMS/get/egamma/2237.html by Diego Figueiredo (although the later report may be something else and perhaps not fixed by this). 

The fix is to assign empty tags for the AOD srcs for these modules when setting up for miniAOD, forcing the minAOD to be read as the AOD src collection is invalid. The heepIDVarMap producer would have had a similar problem but that was already being forced to read only miniAOD via its dataformat option

