### PR TITLE
Updating to Final 2018 Scale& Smearings and new embedding function for pat ele/phos

### DIFF
--- a/RecoEgamma/EgammaTools/python/EgammaPostRecoTools.py
+++ b/RecoEgamma/EgammaTools/python/EgammaPostRecoTools.py
@@ -56,9 +56,9 @@ def _getEnergyCorrectionFile(era):
     if era=="2016-Legacy":
         return "EgammaAnalysis/ElectronTools/data/ScalesSmearings/Legacy2016_07Aug2017_FineEtaR9_v3_ele_unc"
     if era=="2016-Feb17ReMiniAOD":
-        raise RuntimeError('Error in postRecoEgammaTools, era 2016-Feb17ReMiniAOD is not currently implimented') 
+        raise RuntimeError('Error in postRecoEgammaTools, era 2016-Feb17ReMiniAOD is not currently implimented')
     if era=="2018-Prompt":
-        raise RuntimeError('Error in postRecoEgammaTools, era 2018-Prompt does not have energy corrections availible yet, runEnergyCorrections must be set to false') 
+        return "EgammaAnalysis/ElectronTools/data/ScalesSmearings/Run2018_Step2Closure_CoarseEtaR9Gain"
     raise RuntimeError('Error in postRecoEgammaTools, era '+era+' not recognised. Allowed eras are 2017-Nov17ReReco, 2016-Legacy, 2016-Feb17ReMiniAOD')
 
 def _is80XRelease(era):
@@ -320,9 +320,7 @@ def setupEgammaPostRecoSeq(process,
             setupAllVIDIdsInModule(process,idmod,setupVIDPhotonSelection)
 
     if autoAdjustParams:
-        if era == "2018-Prompt" and runEnergyCorrections: 
-            print "EgammaPostRecoTools:\n  2018-Prompt does not yet have residual scales and smearings availible, setting runEnergyCorrections to False. To override, set autoAdjustParams = False"
-            runEnergyCorrections=False
+        pass #no auto adjustment needed
 
     if isMiniAOD:
         _setupEgammaPostRECOSequenceMiniAOD(process,applyEnergyCorrections=applyEnergyCorrections,applyVIDOnCorrectedEgamma=applyVIDOnCorrectedEgamma,era=era,runVID=runVID,runEnergyCorrections=runEnergyCorrections,applyEPCombBug=applyEPCombBug)

--- a/RecoEgamma/EgammaTools/python/EgammaPostRecoTools.py
+++ b/RecoEgamma/EgammaTools/python/EgammaPostRecoTools.py
@@ -58,7 +58,7 @@ def _getEnergyCorrectionFile(era):
     if era=="2016-Feb17ReMiniAOD":
         raise RuntimeError('Error in postRecoEgammaTools, era 2016-Feb17ReMiniAOD is not currently implimented')
     if era=="2018-Prompt":
-        return "EgammaAnalysis/ElectronTools/data/ScalesSmearings/Run2018_Step2Closure_CoarseEtaR9Gain"
+        return "EgammaAnalysis/ElectronTools/data/ScalesSmearings/Run2018_Step2Closure_CoarseEtaR9Gain_v2"
     raise RuntimeError('Error in postRecoEgammaTools, era '+era+' not recognised. Allowed eras are 2017-Nov17ReReco, 2016-Legacy, 2016-Feb17ReMiniAOD')
 
 def _is80XRelease(era):


### PR DESCRIPTION
This PR merges the development branch with the final 2018 scale and smearings into the main branch. 

It also adds a function to embed all the user data in  a pat::Electron/pat::Photon which is useful when you are running in on the AOD and which to make the pat::Electrons/pat::Photons manually. 

